### PR TITLE
Fix tab reuse, activate reused tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,9 @@ toolbarButton.on('click', wallabag.buttonClick);
 
 tabs.on('open', function onOpen(tab) {
   myTab = tab;
-  console.log("onopen");
 });
 
 tabs.on('close', function onClose(tab) {
   delete myTab;
-  console.log("onclose tab");
 });
 

--- a/index.js
+++ b/index.js
@@ -61,10 +61,21 @@ var wallabag = {
         var postUrl = wallabagUrl+"?"+GET.join('&');
 
         if (openTab) {
-            if (typeof myTab !== 'undefined')
+            if (typeof myTab !== 'undefined') {
                 myTab.url = postUrl;
-            else
-                tabs.open(postUrl);
+                myTab.activate();
+            } else
+                tabs.open({
+                    url: postUrl,
+                    onOpen: function onOpen(tab)
+                    {
+                        myTab = tab;
+                    },
+                    onClose: function onClose(tab)
+                    {
+                        delete myTab;
+                    }
+                    });
         } else {
             openDialog({
                 url: postUrl,
@@ -75,12 +86,4 @@ var wallabag = {
 };
 
 toolbarButton.on('click', wallabag.buttonClick);
-
-tabs.on('open', function onOpen(tab) {
-  myTab = tab;
-});
-
-tabs.on('close', function onClose(tab) {
-  delete myTab;
-});
 


### PR DESCRIPTION
    This change fixes reusing a tab. Previously the onOpen and onClose
    methods would react on *all* tab open and close events, which was not
    what I wanted. Now I have an onOpen and onClose handler that only listens
    to events emited from the tab I created.
    
    I also added that if a tab is already in existence, it is not only
    feeded with the new url, but it is also brought into focus.