### PR TITLE
Autoclose setting default is enabled, improve description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     },
     {
         "name": "wallabagAutoclose",
-        "title": "Allow wallabag to close dialog/tab automatically.",
+        "title": "Allow wallabag to close dialog window automatically.",
         "type": "bool",
-        "value": false
+        "value": true
     }
   ]
 }


### PR DESCRIPTION
Autoclose really only has an effect if the dialog window is used. The
description now clearly says so. Secondly, I set the default for
"autoclose" to true, as it was before I made it configurable.

Fixes issue #17.