### PR TITLE
Display the preference dialog if URL not configured.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var self = require('sdk/self');
 var tabs = require('sdk/tabs');
 var workers = require('sdk/content/worker');
+var _ = require("sdk/l10n").get;
 
 var {ActionButton} = require('sdk/ui/button/action');
 var {openDialog} = require('sdk/window/utils');
@@ -23,6 +24,19 @@ function wallabagBagIt(url) {
     var width = prefs.wallabagWidth;
     var openTab = prefs.wallabagOpenTab;
     var autoclose = prefs.wallabagAutoclose;
+    
+    // If the URL is not set in the preferences, open the preference dialog for the add-on.
+    if (!wallabagUrl) {
+        var notifications = require("sdk/notifications");
+        notifications.notify({
+            title: _("cfg_msg_title"),
+            text: _("cfg_msg_text")
+        });
+        var am = require("sdk/preferences/utils");
+        var self = require("sdk/self");
+        am.open(self);
+        return;
+    }
 
     var GET = [
         'action=add',

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ function wallabagBagIt(url) {
             text: _("cfg_msg_text")
         });
         var am = require("sdk/preferences/utils");
-        var self = require("sdk/self");
         am.open(self);
         return;
     }

--- a/locale/en.properties
+++ b/locale/en.properties
@@ -1,0 +1,2 @@
+cfg_msg_title=Wallabag configuration
+cfg_msg_text=Please configure the URL of your Wallabag.

--- a/locale/fr.properties
+++ b/locale/fr.properties
@@ -1,0 +1,3 @@
+
+cfg_msg_title=Configuration de Wallabag
+cfg_msg_text=Veuillez configurer l'URL de votre Wallabag.


### PR DESCRIPTION
Currently, when the URL is not defined and the user press the Wallabag button, a blank popup is displayed. With this modification, the preference form of the add-on is displayed with a notification, which may be more userfriendly.