### PR TITLE
Fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "title": "Wallabag",
-  "name": "poche@gaulupeau.fr",
+  "name": "wallabag",
+  "id": "poche@gaulupeau.fr",
   "version": "2.0.0",
   "description": "Post URL to Wallabag",
   "main": "index.js",


### PR DESCRIPTION
From the [Mozilla JPM documentation][1] we need to
set the id field to the old value for AMO validation
and we need to set the name field to whatever we want
(I went with `wallabag`)

This will fix issue #39 

---

ID handling with jpm

When you create an XPI with jpm xpi:

- if the package.json does not include an id field, then the ID written into the install.rdf is the value of the name field prepended with "@".
- if the package.json does include an id field, and it contains "@", then this is written into the install.rdf as the add-on ID.
- if the package.json does include an id field, and it does not contain "@", then jpm xpi raises an error and the XPI will not be built.

[1]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx_to_jpm#ID_handling_with_jpm