### PR TITLE
Add shortcut key to activate Wallabag. Resolves #42

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var _ = require("sdk/l10n").get;
 
 var {ActionButton} = require('sdk/ui/button/action');
 var {openDialog} = require('sdk/window/utils');
+var {Hotkey} = require('sdk/hotkeys');
 
 var base64 = require('sdk/base64');
 var toolbarButton = ActionButton({
@@ -125,3 +126,37 @@ require("sdk/context-menu").Item({
     wallabagBagIt(pageURL);
   }
 });
+
+var shortcutHotkey = function() {
+  var key = null;
+
+  function getHotkeyPreference() {
+      return require('sdk/simple-prefs').prefs.wallabagShortcutKey;
+  }
+
+  function reset() {
+    if (key) {
+      key.destroy();
+    }
+
+    var newKey = getHotkeyPreference();
+    if (/^\w$/.test(newKey)) {
+      set(newKey);
+    }
+  }
+
+  function set(newKey) {
+    key = Hotkey({
+        combo: 'accel-alt-' + (newKey || getHotkeyPreference()),
+        onPress: wallabag.buttonClick
+    });
+  }
+
+  return {
+    reset: reset,
+    set: set
+  }
+}();
+shortcutHotkey.set();
+
+require("sdk/simple-prefs").on("wallabagShortcutKey", shortcutHotkey.reset);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,13 @@
         "title": "Allow wallabag to close dialog window automatically.",
         "type": "bool",
         "value": true
+    },
+    {
+        "name": "wallabagShortcutKey",
+        "title": "Shortcut key",
+        "description": "Shortcut will be accel-alt-(chosen key value)",
+        "type": "string",
+        "value": "s"
     }
   ]
 }


### PR DESCRIPTION
A new preference option was added with a default of accel-alt-s. The
last character can be modified in the preferences. When modified it will
remove the previous shortcut key and if the new character is valid then
it will add the new shortcut. When the shortcut key is used Wallabag will
be activated.